### PR TITLE
Remove is_proto check in send_feedback()

### DIFF
--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -177,7 +177,6 @@ def send_feedback(
     -------
 
     """
-    is_proto = isinstance(request, prediction_pb2.SeldonMessage)
     seldon_metrics.update_reward(request.reward)
 
     if hasattr(user_model, "send_feedback_rest"):
@@ -194,7 +193,7 @@ def send_feedback(
             try:
                 response = user_model.send_feedback_raw(request)
                 handle_raw_custom_metrics(
-                    response, seldon_metrics, is_proto, FEEDBACK_METRIC_METHOD_TAG
+                    response, seldon_metrics, True, FEEDBACK_METRIC_METHOD_TAG
                 )
                 return response
             except SeldonNotImplementedError:


### PR DESCRIPTION
**What this PR does / why we need it**:
By type definition of the request parameter in the input signature, `is_proto` was always incorrectly set to False. This resulted in `handle_raw_custom_metrics` acting as a no-op on implementations of `send_feedback` which matched specification.

This PR removes the `isinstance` check on the request parameter since it is always true unless the caller is not respecting argument types. If the caller is not respecting argument types, the method would crash anyway upon calling `seldon_metrics.update_reward(request.reward)` thus I suspect there is no need to protect against such a scenario for reverse compatibility.

**Which issue(s) this PR fixes**:
Fixes #2606

**Special notes for your reviewer**:
I opted not to add complexity to the `handle_raw_custom_metrics` but it may be worth considering refactoring that method to not use the `is_proto` flag and merely handle `isinstance()` checking within the method itself.

**Does this PR introduce a user-facing change?**:
```release-note
Fixes no-op in emitting custom metrics on send_feedback API calls.
```

